### PR TITLE
Allow external preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,13 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Open <http://localhost:5000> to view your timeline.
+The app now listens on all interfaces by default so it can be previewed
+from a remote environment. To change the port, set the `PORT` environment
+variable before running:
+
+```bash
+PORT=8000 python app.py
+```
+
+Then open `http://localhost:8000` (or the forwarded port in your environment)
+to view your timeline.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, redirect, url_for
+import os
 
 app = Flask(__name__)
 
@@ -27,4 +28,6 @@ def new_post():
     return render_template('new_post.html')
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    host = os.environ.get('HOST', '0.0.0.0')
+    port = int(os.environ.get('PORT', 5000))
+    app.run(debug=True, host=host, port=port)


### PR DESCRIPTION
## Summary
- serve Flask app on externally accessible host/port for remote previews
- document port configuration and preview instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68982e680248832c894f358e6c2fe786